### PR TITLE
Made the input fields not look out of place in dark mode

### DIFF
--- a/jiten/static/style-dark.css
+++ b/jiten/static/style-dark.css
@@ -14,3 +14,17 @@ hr {
 .border {
   border: 1px solid #444 !important;
 }
+
+.form-control {
+	background-color: #333 !important;
+	color: #ddd
+}
+
+.form-control:focus {
+	background-color: #333;
+	color: #ddd
+}
+
+.form-control::placeholder {
+	color: #888
+}


### PR DESCRIPTION
The appearance of the input fields didn’t change when I turned on dark mode in the settings, so I added a few CSS rules so that they blend in more among the rest of the elements.

Here’s how it looks with these changes for me:

![Screenshot_2021-03-23 jiten](https://user-images.githubusercontent.com/10419911/112207978-18e9a080-8c18-11eb-8c0e-caf8e41d599c.png)