### PR TITLE
Respect $PAGER environment variable

### DIFF
--- a/jiten/cli.py
+++ b/jiten/cli.py
@@ -508,8 +508,9 @@ def cli(ctx, colour, pager, **kw):
   if colour is not None: ctx.color = colour
   if pager:
     os.environ["PAGER"] = pager
-  elif not os.getenv("PAGER") or os.getenv("PAGER") == "less":
-    os.environ["PAGER"] = "less -FR"
+  elif pager is None: # do not set pager with -p ''
+    if not os.getenv("PAGER") or os.getenv("PAGER") == "less":
+      os.environ["PAGER"] = "less -FR"
   ctx.obj = dict(kw)
 
 @cli.command(help = """

--- a/jiten/cli.py
+++ b/jiten/cli.py
@@ -496,7 +496,7 @@ def android_link_dbs():
 @click.option("-v", "--verbose", is_flag = True, help = "Be verbose.")
 @click.option("-c", "--colour/--no-colour", is_flag = True,
               default = None, help = "Use terminal colours.")
-@click.option("-p", "--pager", default = "less -FR",
+@click.option("-p", "--pager", default = None,
               show_default = True,
               help = "Set $PAGER (unless empty).")
 @click.version_option(
@@ -506,7 +506,10 @@ def android_link_dbs():
 @click.pass_context
 def cli(ctx, colour, pager, **kw):
   if colour is not None: ctx.color = colour
-  if pager: os.environ["PAGER"] = pager
+  if pager:
+    os.environ["PAGER"] = pager
+  elif not os.getenv("PAGER") or os.getenv("PAGER") == "less":
+    os.environ["PAGER"] = "less -FR"
   ctx.obj = dict(kw)
 
 @cli.command(help = """


### PR DESCRIPTION
Hi, thanks for writing this program, it's very useful.

This is a short patch I have used for a while to keep default `$PAGER` values even without the -p flag.

Normally, jiten would override it with `less` unless the user explicitly set the pager through -p. But I use a more capable pager than less, and having to set the pager for every jiten call is inconvenient.

Originally, I just ignored the "less -FR" default when `$PAGER` was set.  But this is problematic from a backward-compatibility perspective: currently, the "-FR" options are added even if the user's `$PAGER` equals "less", as it is by default on many operating systems. On such systems you would suddenly get the `less` UI for single-page entries too, even though it just dumped those to standard out before.

So I made it set "less -FR" if `$PAGER` is missing or equals the string "less", which should be compatible with the old behavior.
